### PR TITLE
Use data URLs instead of paths

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,2 +1,6 @@
 declare module 'electron-squirrel-startup';
 declare module 'opsgenie-sdk';
+declare module '*.png' {
+  const value: string;
+  export = value;
+}

--- a/src/main/TrayMenu.test.ts
+++ b/src/main/TrayMenu.test.ts
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker';
 import { State } from '../types/State';
 import { Status } from '../types/Status';
-import { join } from 'path';
 import { Tray, nativeImage, Menu } from 'electron';
 import { TrayMenu } from './TrayMenu';
 import { expect, describe, it, vi, beforeEach, Mock } from 'vitest';
+
+import naIcon from '../assets/na_icon.png';
+import okIcon from '../assets/ok_icon.png';
 
 vi.mock('../i18n', () => ({
   translate: (val: string): string => val,
@@ -12,7 +14,7 @@ vi.mock('../i18n', () => ({
 
 vi.mock('electron', () => ({
   nativeImage: {
-    createFromPath: vi.fn(),
+    createFromDataURL: vi.fn(),
   },
   Menu: {
     buildFromTemplate: vi.fn(),
@@ -22,7 +24,7 @@ vi.mock('electron', () => ({
 
 describe('TrayMenu', () => {
   const trayMock = Tray as any;
-  const createFromPathMock: Mock<any> = nativeImage.createFromPath as any;
+  const createFromDataURLMock: Mock<any> = nativeImage.createFromDataURL as any;
   const buildFromTemplateMock: Mock<any> = Menu.buildFromTemplate as any;
   const expectedImage = {
     setTemplateImage: vi.fn(),
@@ -36,19 +38,19 @@ describe('TrayMenu', () => {
   };
   beforeEach(() => {
     trayMock.mockClear();
-    createFromPathMock.mockClear();
+    createFromDataURLMock.mockClear();
     buildFromTemplateMock.mockClear();
     expectedImage.setTemplateImage.mockClear();
     expectedTray.setContextMenu.mockClear();
     expectedTray.setImage.mockClear();
-    createFromPathMock.mockReturnValue(expectedImage);
+    createFromDataURLMock.mockReturnValue(expectedImage);
     buildFromTemplateMock.mockReturnValue(expectedMenu);
     trayMock.mockReturnValue(expectedTray);
   });
   describe('Constructor', () => {
     it('generates correct instance', () => {
       const tray = new TrayMenu();
-      expect(createFromPathMock).toBeCalledWith(join(__dirname, '..', 'assets', 'na_icon.png'));
+      expect(createFromDataURLMock).toBeCalledWith(naIcon);
       expect(trayMock).toBeCalledWith(expectedImage);
       expect(buildFromTemplateMock).toHaveBeenCalledWith(tray.defaultMenuItems);
       expect(expectedTray.setContextMenu).toBeCalledWith(expectedMenu);
@@ -64,7 +66,7 @@ describe('TrayMenu', () => {
         link: faker.internet.url(),
       });
 
-      expect(createFromPathMock).toBeCalledWith(join(__dirname, '..', 'assets', 'ok_icon.png'));
+      expect(createFromDataURLMock).toBeCalledWith(okIcon);
       expect(expectedTray.setImage).toBeCalledWith(expectedImage);
     });
   });

--- a/src/main/TrayMenu.ts
+++ b/src/main/TrayMenu.ts
@@ -1,10 +1,14 @@
 import { app, Tray, Menu, nativeImage, MenuItemConstructorOptions, shell } from 'electron';
 import { appManager } from './AppManager';
-import { join } from 'path';
 import { State } from '../types/State';
 import { Status } from '../types/Status';
 import { MapType } from '../types/MapType';
 import { translate } from '../i18n';
+
+import okIcon from '../assets/ok_icon.png';
+import failIcon from '../assets/fail_icon.png';
+import runningIcon from '../assets/running_icon.png';
+import naIcon from '../assets/na_icon.png';
 
 export class TrayMenu {
   public readonly tray: Tray;
@@ -28,10 +32,10 @@ export class TrayMenu {
   ];
 
   public readonly statusToImagePathMap: MapType<string> = {
-    [Status.SUCCESS]: join(__dirname, '..', 'assets', 'ok_icon.png'),
-    [Status.FAILURE]: join(__dirname, '..', 'assets', 'fail_icon.png'),
-    [Status.CHECKING]: join(__dirname, '..', 'assets', 'running_icon.png'),
-    [Status.NA]: join(__dirname, '..', 'assets', 'na_icon.png'),
+    [Status.SUCCESS]: okIcon,
+    [Status.FAILURE]: failIcon,
+    [Status.CHECKING]: runningIcon,
+    [Status.NA]: naIcon,
   };
 
   constructor() {
@@ -40,7 +44,7 @@ export class TrayMenu {
   }
 
   public updateTrayImage(state: State) {
-    const image = nativeImage.createFromPath(this.getIconForState(state));
+    const image = nativeImage.createFromDataURL(this.getIconForState(state));
     this.tray.setImage(image);
   }
 
@@ -49,7 +53,7 @@ export class TrayMenu {
       return {
         label: observerState.name,
         submenu: [{ label: translate('Link'), click: () => shell.openExternal(observerState.link) }],
-        icon: nativeImage.createFromPath(this.getIconForState(observerState)),
+        icon: nativeImage.createFromDataURL(this.getIconForState(observerState)),
       };
     });
     this.tray.setContextMenu(
@@ -62,7 +66,7 @@ export class TrayMenu {
   }
 
   private createNativeImage() {
-    const image = nativeImage.createFromPath(this.statusToImagePathMap[Status.NA]);
+    const image = nativeImage.createFromDataURL(this.statusToImagePathMap[Status.NA]);
     return image;
   }
 


### PR DESCRIPTION
<!--
Thank you for your PR!
Please take a moment to complete this guide, it helps us to understand the objective of your PR and makes it easier to review.
-->

### Checklist

- [x] I have follow the [contribution guidelines](https://github.com/barklarm/barklarm-app/blob/main/CONTRIBUTING.md)

### Description

<!--
Please include here a little description, screenshots to make your submission review easier for the folks
-->
I was having an issue with the tray icons. It was looking for them in `.vite/build/../assets`. Importing the images fixes the issue, but it looks like `join()` it's a common pattern throughout the codebase.